### PR TITLE
fix: set foreground color

### DIFF
--- a/gtk4/rose-pine-dawn.css
+++ b/gtk4/rose-pine-dawn.css
@@ -40,3 +40,4 @@
 
 @define-color sidebar_backdrop_color #f2e9e1;
 @define-color sidebar_bg_color #f2e9e1;
+@define-color sidebar_fg_color #575279;

--- a/gtk4/rose-pine-moon.css
+++ b/gtk4/rose-pine-moon.css
@@ -40,3 +40,4 @@
 
 @define-color sidebar_backdrop_color #393552;
 @define-color sidebar_bg_color #393552;
+@define-color sidebar_fg_color #e0def4;

--- a/gtk4/rose-pine.css
+++ b/gtk4/rose-pine.css
@@ -40,3 +40,4 @@
 
 @define-color sidebar_backdrop_color #26233A;
 @define-color sidebar_bg_color #26233A;
+@define-color sidebar_fg_color #e0def4;


### PR DESCRIPTION
This PR fixed the sidebar foreground color on applications like Nautilus. 

Without this fix:
![image](https://github.com/user-attachments/assets/e5a7b329-6c96-495c-b9ba-cfaaff86b451)

With this fix:
![image](https://github.com/user-attachments/assets/d8381018-bf04-4880-89c4-d08a26198214)
